### PR TITLE
Create publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,41 @@
+name: Publish Python to PyPI 📦
+
+on:
+ release:
+    types:
+      - published
+      
+ workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"    
+        
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+        
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+        
+    - name: Publish distribution to PyPI 📦
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Summary
========
I have added a GitHub Actions workflow to automate the publishing of this module to PyPI on releases for ease and convenience. Please note that I have not tested this workflow, so it is important for you to test it yourself. Additionally, you can modify the "publish-to-pypi.yml" file to suit your specific requirements. For example, you can customize it to publish on pushed commits that include a tag. You can find more information on how to do this in the [official PyPI documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

How to Use
=========
To use this workflow, you need to create an API token for PyPI. You can do this by visiting the [PyPI account page](https://pypi.org/manage/account/#api-tokens). Once you have the API token, go to the Settings tab of your repository on GitHub, click on Secrets in the left sidebar, and add a secret named ```PYPI_API_TOKEN``` with the value set to your API token.
Finally, you can test the workflow by using the ```workflow_dispatcher``` that I have created.

If you require any further information, please feel free to reach out to me.